### PR TITLE
Update for .NET 5

### DIFF
--- a/generators/app/templates/AuthenticationHandler.cs
+++ b/generators/app/templates/AuthenticationHandler.cs
@@ -76,7 +76,7 @@ namespace AspNet.Security.OAuth.<%= name %>
             context.RunClaimActions();
 
             await Options.Events.CreatingTicket(context);
-            return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
+            return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }
 }

--- a/generators/app/templates/Project.csproj
+++ b/generators/app/templates/Project.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-aspnet-oauth",
-  "version": "3.1.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-aspnet-oauth",
-  "version": "3.1.0",
+  "version": "5.0.0",
   "description": "Yeoman generator for OAuth Providers for ASP.NET Core",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
* Use `$(DefaultNetCoreTargetFramework)` instead of a literal target framework (see aspnet-contrib/AspNet.Security.OAuth.Providers#574).
* Add operator to fix compiler warning/error when nullable is enabled.
