### PR TITLE
Remove ISystemClock

### DIFF
--- a/generators/app/templates/AuthenticationHandler.cs
+++ b/generators/app/templates/AuthenticationHandler.cs
@@ -26,13 +26,11 @@ public partial class <%= name %>AuthenticationHandler : OAuthHandler<<%= name %>
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public <%= name %>AuthenticationHandler(
         [NotNull] IOptionsMonitor<<%= name %>AuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 


### PR DESCRIPTION
Remove usage of `ISystemClock` to fix obsolete warning.
