### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
         node-version: '22.x'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Update npm
+      run: npm install -g npm@latest
+
     - name: Install packages
       run: |
         npm ci

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Yeoman generator for OAuth Providers for ASP.NET Core",
   "license": "MIT",
   "main": "app/index.js",
-  "repository": "aspnet-contrib/generator-aspnet-oauth",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aspnet-contrib/generator-aspnet-oauth.git"
+  },
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
- Run `npm pkg fix` to fix package metadata.
- Update to the latest version of `npm` to ensure trusted publishing is available.
